### PR TITLE
Rename ssh-key variable and skip auto-promotion when not deploying to pantheon dev env

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: "Report something that's broken or otherwise not working as expected."
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report!
+        Before submitting your issue, please ensure that you have read our [Code of Conduct](https://github.com/alleyinteractive/.github/blob/main/CODE_OF_CONDUCT.md) and you have read through existing issues (opened and closed) so as to avoid creating duplicates. 🙏
+
+  - type: textarea
+    attributes:
+      id: bug-description
+      label: Description of the bug
+      description: Please write a brief description of the bug, including what you expect to happen and what is currently happening.
+      placeholder: |
+        <Some feature> is not working properly.
+        I would expect <x> to happen, but instead <y> happens.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Provide detailed steps to reproduce your issue.
+      placeholder: |
+        1. Configure <...> with <...>
+        2. Go to <...>
+        3. Click on <...>
+        4. Scroll down to <...>
+        5. See error <...>
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: |
+        Provide any additional information such as logs, links, gists, screenshots, scenarios in which the bug occurs so that it facilitates resolving the issue, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs_update_request.yml
+++ b/.github/ISSUE_TEMPLATE/docs_update_request.yml
@@ -1,0 +1,27 @@
+name: Documentation Update
+description: "Report something in the project documentation that is incorrect or otherwise inaccurate."
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this documentation update request!
+        Before submitting your issue, please ensure that you have read our [Code of Conduct](https://github.com/alleyinteractive/.github/blob/main/CODE_OF_CONDUCT.md) and you have read through existing issues (opened and closed) so as to avoid creating duplicates. 🙏
+
+  - type: textarea
+    attributes:
+      id: documentation-inaccuracy-description
+      label: Description of the documentation inaccuracy
+      description: Please write a brief description of the documentation that you believe should be updated, including what you expect to see and what is currently included in the docs.
+      placeholder: |
+        Within <some section> of the documentation, <some text> is not correct.
+        It says <x>, but looking at the code, it should say <y>.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: |
+        Provide any additional information such as logs, links, gists, screenshots, etc, so that it facilitates our understanding of the inaccuracy.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature or Enhancement Request
+description: Request a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting your issue, please ensure that you have read our [Code of Conduct](https://github.com/alleyinteractive/.github/blob/main/CODE_OF_CONDUCT.md) and you have read through existing issues so as to avoid creating duplicates. 🙏
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Provide a detailed description of the feature or enhancement you would like to see incorporated.
+      placeholder: |
+        I would like to see <...> incorporated into <...> so that <...> can be achieved.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Use Case
+      description: Provide a detailed description of the use case for this feature/enhancement.
+      placeholder: |
+        When a user <...> they should be able to <...> so that they don't have to <...>.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/for-discussion.yml
+++ b/.github/ISSUE_TEMPLATE/for-discussion.yml
@@ -1,0 +1,17 @@
+name: For Discussion
+description: Open a topic for discussion
+labels: ["discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting your issue, please ensure that you have read our [Code of Conduct](https://github.com/alleyinteractive/.github/blob/main/CODE_OF_CONDUCT.md) and you have read through existing issues so as to avoid creating duplicates. 🙏 
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Provide a detailed description of topic you wish to open for discussion.
+      placeholder: |
+        Should this codebase consider <...> so that <...> can be achieved?
+    validations:
+      required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `Deploy to Pantheon Action` will be documented in this file.
 
-## 1.0.0 - 2023-11-10
+## 0.0.2 - 2023-11-09
+
+- The configuration option name has been changed from `ssh_key` to `ssh-key`. This change affects the SSH key used for remote repository authentication in upstream action [deploy-to-remote-repository](https://github.com/marketplace/actions/deploy-to-remote-repository-action)
+
+## 0.0.1 - 2023-11-09
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ rooted at `wp-content` but still want to version control their Pantheon configur
 - Defaults to `.git, .gitmodules, .pantheon`.
 - Inherited from `action-deploy-to-remote-repository`.
 
-### `ssh_key`
+### `ssh-key`
 
 - SSH key to use for remote repository authentication.
 - Accepts a string (private key).

--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,8 @@ runs:
     - name: "Deploy to Pantheon environment ${{ inputs.pantheon_env_name }}"
       shell: bash
       run: |
-        # If the pantheon_env_name is 'production' or 'dev', deploy to dev.
-        if [ "${{ inputs.pantheon_env_name }}" == "production" || "${{ inputs.pantheon_env_name }}" == "dev" ]; then
+        # If the pantheon_env_name is 'production', 'master', or 'dev', deploy to dev.
+        if [ "${{ inputs.pantheon_env_name }}" == "production" || "${{ inputs.pantheon_env_name }}" == "master" || "${{ inputs.pantheon_env_name }}" == "dev" ]; then
           echo "Deploying to dev environment."
           terminus env:deploy ${{ inputs.pantheon_site }}.dev --note="$(git log -1 --pretty=%B)"
         else # Otherwise, deploy to the specified (multisite) environment.
@@ -75,15 +75,15 @@ runs:
           terminus env:deploy ${{ inputs.pantheon_site }}.${{ inputs.pantheon_env_name }} --note="$(git log -1 --pretty=%B)"
         fi
     - name: Autopromote dev to test
-      # Skipped if autopromote is false.
-      if: ${{ inputs.autopromote == 'true' }}
+      # Skipped if autopromote is false or we're not deploying to the dev environment.
+      if: ${{ inputs.autopromote == 'true' && (inputs.pantheon_env_name == 'production' || inputs.pantheon_env_name == 'master' || inputs.pantheon_env_name == 'dev') }}
       shell: bash
       run: |
         echo "Autopromoting dev to test."
         terminus env:deploy ${{ inputs.pantheon_site }}.test --note="$(git log -1 --pretty=%B)"
     - name: Autopromote test to live
-      # Skipped if autopromote is false.
-      if: ${{ inputs.autopromote == 'true' }}
+      # Skipped if autopromote is false or we're not deploying to the dev environment.
+      if: ${{ inputs.autopromote == 'true' && (inputs.pantheon_env_name == 'production' || inputs.pantheon_env_name == 'master' || inputs.pantheon_env_name == 'dev') }}
       shell: bash
       run: |
         echo "Autopromoting test to live."

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: 'Comma-separated list of files and directories to exclude from sync'
     required: false
     default: '.git, .gitmodules, .pantheon'
-  ssh_key:
+  ssh-key:
     description: 'SSH key to use for remote repository authentication.'
     required: true
   # Pantheon-specific inputs
@@ -49,7 +49,7 @@ runs:
         base_directory: ${{ inputs.base_directory }}
         destination_directory: ${{ inputs.destination_directory }}
         exclude_list: ${{ inputs.exclude_list }}
-        ssh-key: ${{ inputs.ssh_key }}
+        ssh-key: ${{ inputs.ssh-key }}
         # Special case. If inputs.pantheon_env_name is 'production' or 'dev', use 'master' instead.
         remote_branch: ${{ inputs.pantheon_env_name == 'production' && 'master' || inputs.pantheon_env_name == 'dev' && 'master' || inputs.pantheon_env_name }}
         pantheon: 'true'


### PR DESCRIPTION
- Update the `ssh-key` variable name from `ssh_key` to more closely mirror the upstream (action-deploy-to-remote-repository) name conventions
- Ensure that autopromotion is *also* skipped when not deploying to a pantheon_env_name of `master`, `dev`, or `production`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README and CHANGELOG to reflect the change in configuration option name from `ssh_key` to `ssh-key`.
- **Refactor**
	- Changed the SSH key configuration option for remote repository authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->