### PR TITLE
Issue-4: `base_directory` default is not the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `Deploy to Pantheon Action` will be documented in this file.
 
+## 2.0.0 - 2025-01-28
+
+- Default `destination_directory` is now `wp-content/` instead of `.` to match repository structure.
+- Default `exclude_list` is now `.git, .gitmodules, .pantheon, uploads` (added `uploads` to exclude list).
+
+## 1.0.0 - 2024-01-08
+
+- Initial stable release
+
 ## 0.0.2 - 2023-11-09
 
 - The configuration option name has been changed from `ssh_key` to `ssh-key`. This change affects the SSH key used for remote repository authentication in upstream action [deploy-to-remote-repository](https://github.com/marketplace/actions/deploy-to-remote-repository-action)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
     # ...
 
     - name: Deploy to Pantheon
-      uses: alleyinteractive/action-deploy-to-pantheon@v1.0.0
+      uses: alleyinteractive/action-deploy-to-pantheon@develop
       with:
         pantheon_site: 'your-site-name'
         pantheon_site_id: '12345678-YOUR-SITE-ID00-123456789123'

--- a/README.md
+++ b/README.md
@@ -55,18 +55,22 @@ rooted at `wp-content` but still want to version control their Pantheon configur
 > Specify using `with` keyword. See all upstream inputs for [action-deploy-to-remote-repository](https://github.com/alleyinteractive/action-deploy-to-remote-repository).
 
 ### `base_directory`
+**NOTE:** _You likely want a
+  trailing slash if you're syncing from a subdirectory. (eg. `wp-content/`)_
+
 
 - Specify the base directory to sync from.
 - Accepts a string.
-- Defaults to the root of the repository (`.`). **NOTE** You likely want a
-  trailing slash if you're syncing a subdirectory. (eg. `wp-content/`)
+- Defaults to the root of the repository (`.`).
 - Inherited from `action-deploy-to-remote-repository`.
 
 ### `destination_directory`
+**NOTE:** _You likely want a
+  trailing slash if you're syncing to a subdirectory. (eg. `wp-content/`)_
 
 - Specify the destination directory to sync to.
 - Accepts a string.
-- Defaults to the root of the remote repository (`.`).
+- Defaults to wp-content within the Pantheon repository (`wp-content/`).
 - Inherited from `action-deploy-to-remote-repository`.
 
 ### `exclude_list`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ _Notes_:
 
 - This action depends upon the upstream action [action-deploy-to-remote-repository](https://github.com/alleyinteractive/action-deploy-to-remote-repository) and it's associated requirements (eg. [ssh-key](https://github.com/alleyinteractive/action-deploy-to-remote-repository#ssh-key).
 - This action assumes that `production` branches are deployed to Pantheon `dev` environment (via a git commit to Pantheon's `master` branch), and all other `branch` names are deployed to a Pantheon multisite `branch` environment of the same name (unless overridden with [pantheon_env_name](#pantheon_env_name)).
+- This action assumes that your Pantheon site is set to `git` mode and not `sftp` mode.
 - If autopromote is set, the action will use `terminus env:deploy` to advance from `dev` -> `test` -> `live` Pantheon environments.
 - There are special considerations for the [.pantheon folder](#pantheon-folder).
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ rooted at `wp-content` but still want to version control their Pantheon configur
 ### `exclude_list`
 
 - Specify a comma-separated list of files and directories to exclude from sync.
-- Accepts a string. (e.g. `.git, .gitmodules`)
-- Defaults to `.git, .gitmodules, .pantheon`.
+- Accepts a string. (e.g. `.git, .gitmodules, uploads`)
+- Defaults to `.git, .gitmodules, .pantheon, uploads`.
 - Inherited from `action-deploy-to-remote-repository`.
 
 ### `ssh-key`

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,11 @@ inputs:
   base_directory:
     description: 'Base directory for rsync'
     required: false
+    default: '.'
   destination_directory:
-    description: 'Destination directory for rsync in remote repository'
+    description: 'Destination directory for rsync in remote repository including trailing slash'
     required: false
+    default: 'wp-content/'
   exclude_list:
     description: 'Comma-separated list of files and directories to exclude from sync'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   exclude_list:
     description: 'Comma-separated list of files and directories to exclude from sync'
     required: false
-    default: '.git, .gitmodules, .pantheon'
+    default: '.git, .gitmodules, .pantheon, uploads'
   ssh-key:
     description: 'SSH key to use for remote repository authentication.'
     required: true


### PR DESCRIPTION
## Summary

Need to cut a new major release as default options are changing.

Fixes #4

## Changes

- Implemented a fix to ensure `base_directory` has the stated default value (`.`) if not specified by the user.
- Set `wp-content/` as the default for `destination_directory`.
- Added `uploads` to the `exclude_list` default.
- Updated the example version used in documentation to `develop` for better clarity.
- Updated CHANGELOG

## How to test

- Create a pantheon deploy action, specify a `destination_directory` and do not specify a `base_directory`.
- Run the workflow and observe that it completes successfully without the previously encountered rsync error.